### PR TITLE
Pin dependency versions and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-reflutter
-objection
-frida-tools
-bs4
-click
-psutil
+reflutter==0.7.8
+objection==1.11.0
+frida-tools==12.3.0
+bs4==0.0.2
+click==8.1.7
+psutil==5.9.8


### PR DESCRIPTION
This pins the versions of the dependencies in the requirements.txt file to ensure consistent behavior despite external changes. It also adds a configuration file for Dependabot, which will automatically check for updates to these dependencies on a weekly basis and creates pull requests for you to review.